### PR TITLE
fix: count online devices by unique IP instead of raw connections

### DIFF
--- a/internal/kernel/xray/dispatcher.go
+++ b/internal/kernel/xray/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/netip"
 	"reflect"
 	"sort"
 	"strconv"
@@ -61,6 +62,10 @@ func limitDispatcherFactory(ctx context.Context, config interface{}) (interface{
 	slog.Debug("xray: limit dispatcher installed")
 	return ld, nil
 }
+
+// maxConns caps the xray dispatcher's connection map to prevent OOM under
+// connection floods. This is analogous to sing-box's maxPending.
+const maxConns = 100_000
 
 // LimitDispatcher wraps xray's DefaultDispatcher to add per-user device
 // limit enforcement, speed limiting, and per-connection source IP tracking.
@@ -156,6 +161,11 @@ func (d *LimitDispatcher) wrapLink(ctx context.Context, link *transport.Link, em
 	}
 
 	d.mu.Lock()
+	if len(d.conns) >= maxConns {
+		d.mu.Unlock()
+		slog.Warn("xray: conns map at capacity, skipping tracking", "cap", maxConns, "email", email)
+		return
+	}
 	d.conns[connID] = dc
 	d.mu.Unlock()
 
@@ -303,16 +313,26 @@ func (d *LimitDispatcher) checkDeviceLimit(email, sourceIP string, isTCP bool) b
 		return false
 	}
 
-	// Over limit — deterministic: allow lowest IPs lexicographically
-	ipList := make([]string, 0, len(ips)+1)
-	for ip := range ips {
-		ipList = append(ipList, ip)
+	// Over limit — deterministic: allow lowest IPs by numeric address.
+	// Uses netip.Addr.Compare for consistency with the sing-box limiter,
+	// avoiding lexicographic quirks (e.g. "10.x" vs "192.x", IPv6 ordering).
+	type parsedIP struct {
+		raw  string
+		addr netip.Addr
 	}
-	ipList = append(ipList, sourceIP)
-	sort.Strings(ipList)
+	ipList := make([]parsedIP, 0, len(ips)+1)
+	for ip := range ips {
+		a, _ := netip.ParseAddr(ip)
+		ipList = append(ipList, parsedIP{raw: ip, addr: a})
+	}
+	srcAddr, _ := netip.ParseAddr(sourceIP)
+	ipList = append(ipList, parsedIP{raw: sourceIP, addr: srcAddr})
+	sort.Slice(ipList, func(i, j int) bool {
+		return ipList[i].addr.Compare(ipList[j].addr) < 0
+	})
 
 	for i := 0; i < limit && i < len(ipList); i++ {
-		if ipList[i] == sourceIP {
+		if ipList[i].raw == sourceIP {
 			if isTCP {
 				ips[sourceIP]++
 			}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -784,7 +784,10 @@ func (s *Service) executeKicks(ctx context.Context, kicks []limiter.KickAction) 
 	}
 }
 
-// pushReport sends consolidated traffic + alive + status to the panel
+// pushReport sends consolidated traffic + alive + status to the panel.
+// When WebSocket is connected, node.status is already sent every 10s via WS,
+// so we still push the full report (traffic/alive/online) but at the normal
+// pushInterval — the panel deduplicates metrics from both channels.
 func (s *Service) pushReport() {
 	if s.pushBackoff.shouldSkip() {
 		slog.Debug("skipping report due to backoff")
@@ -793,7 +796,7 @@ func (s *Service) pushReport() {
 
 	traffic := s.tracker.FlushTraffic()
 	aliveIPs := s.tracker.FlushAliveIPs()
-	online := s.tracker.CurrentOnline()
+	online := s.tracker.FlushOnline()
 	status := monitor.Collect()
 
 	metrics := s.buildMetrics(status)
@@ -815,12 +818,15 @@ func (s *Service) pushReport() {
 		if len(aliveIPs) > 0 {
 			s.tracker.RestoreAliveIPs(aliveIPs)
 		}
+		if len(online) > 0 {
+			s.tracker.RestoreOnline(online)
+		}
 		s.pushBackoff.onFailure()
 		return
 	}
 
 	s.pushBackoff.onSuccess()
-	slog.Info("report pushed", "users_with_traffic", len(traffic), "online", len(online))
+	slog.Info("report pushed", "users_with_traffic", len(traffic), "online_devices", len(online))
 }
 
 // buildMetrics aggregates node-level metrics to be reported to the panel.

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -32,7 +32,7 @@ type Tracker struct {
 	connState map[string][2]int64     // conn_id → last [upload, download]
 	traffic   map[int][2]int64        // user_id → accumulated [upload, download]
 	aliveIPs  map[int]map[string]bool // user_id → set of source IPs
-	online    map[int]int             // user_id → current active connection count
+	online    map[int]int             // user_id → unique device count (unique IPs)
 
 	// ② Reused buffer: cleared each Process() call, not reallocated.
 	activeConns map[string]struct{}
@@ -91,7 +91,7 @@ func (t *Tracker) Process(conns []kernel.Connection) map[int][2]int64 {
 		}
 	}
 
-	// Clear online counts
+	// Clear online counts (will be rebuilt from unique IPs below)
 	for uid := range t.online {
 		delete(t.online, uid)
 	}
@@ -102,8 +102,6 @@ func (t *Tracker) Process(conns []kernel.Connection) map[int][2]int64 {
 		if conn.UserID == 0 {
 			continue
 		}
-
-		t.online[conn.UserID]++
 
 		var deltaUp, deltaDown int64
 		prev, exists := t.connState[conn.ID]
@@ -151,6 +149,14 @@ func (t *Tracker) Process(conns []kernel.Connection) map[int][2]int64 {
 			if len(ips) < t.maxAliveIPsPerUser {
 				ips[conn.SourceIP] = true
 			}
+		}
+	}
+
+	// Rebuild online counts from unique IPs (device count, not connection count).
+	// This ensures online[uid] == number of distinct source IPs for that user.
+	for uid, ips := range t.aliveIPs {
+		if n := len(ips); n > 0 {
+			t.online[uid] = n
 		}
 	}
 
@@ -220,7 +226,26 @@ func (t *Tracker) FlushAliveIPs() map[int][]string {
 	return data
 }
 
-// CurrentOnline returns a map of user_id to active connection count.
+// FlushOnline returns a snapshot of per-user online device counts and resets.
+// This makes online consistent with FlushTraffic/FlushAliveIPs: the caller
+// gets an owned copy and the tracker starts fresh.
+func (t *Tracker) FlushOnline() map[int]int {
+	data := t.online
+	t.online = make(map[int]int, len(data))
+	return data
+}
+
+// RestoreOnline merges online counts back (used when push to panel fails).
+func (t *Tracker) RestoreOnline(data map[int]int) {
+	for uid, count := range data {
+		if count > t.online[uid] {
+			t.online[uid] = count
+		}
+	}
+}
+
+// CurrentOnline returns a reference to the current online map (read-only).
+// Prefer FlushOnline for report pushes to ensure atomicity with restore.
 func (t *Tracker) CurrentOnline() map[int]int {
 	return t.online
 }

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -254,6 +254,60 @@ func TestProcess_NoTrafficDelta(t *testing.T) {
 	}
 }
 
+func TestOnlineCountsUniqueIPs(t *testing.T) {
+	tr := New()
+	// 1 user, 3 connections from 2 unique IPs → online should be 2 (not 3)
+	conns := []kernel.Connection{
+		{ID: "c1", UserID: 1, Upload: 100, Download: 200, SourceIP: "1.1.1.1"},
+		{ID: "c2", UserID: 1, Upload: 50, Download: 80, SourceIP: "1.1.1.1"},
+		{ID: "c3", UserID: 1, Upload: 30, Download: 40, SourceIP: "2.2.2.2"},
+	}
+	tr.Process(conns)
+
+	online := tr.CurrentOnline()
+	if online[1] != 2 {
+		t.Errorf("online should count unique IPs: got %d, want 2", online[1])
+	}
+}
+
+func TestFlushOnline(t *testing.T) {
+	tr := New()
+	tr.Process([]kernel.Connection{
+		{ID: "c1", UserID: 1, Upload: 100, Download: 200, SourceIP: "1.1.1.1"},
+		{ID: "c2", UserID: 1, Upload: 50, Download: 80, SourceIP: "2.2.2.2"},
+		{ID: "c3", UserID: 2, Upload: 30, Download: 40, SourceIP: "3.3.3.3"},
+	})
+
+	flushed := tr.FlushOnline()
+	if flushed[1] != 2 {
+		t.Errorf("user 1 online: got %d, want 2", flushed[1])
+	}
+	if flushed[2] != 1 {
+		t.Errorf("user 2 online: got %d, want 1", flushed[2])
+	}
+
+	// After flush, should be empty
+	flushed2 := tr.FlushOnline()
+	if len(flushed2) != 0 {
+		t.Errorf("expected empty after second flush, got %v", flushed2)
+	}
+}
+
+func TestRestoreOnline(t *testing.T) {
+	tr := New()
+	tr.Process([]kernel.Connection{
+		{ID: "c1", UserID: 1, Upload: 100, Download: 200, SourceIP: "1.1.1.1"},
+	})
+
+	flushed := tr.FlushOnline()
+	tr.RestoreOnline(flushed)
+
+	restored := tr.FlushOnline()
+	if restored[1] != 1 {
+		t.Errorf("restored online: got %d, want 1", restored[1])
+	}
+}
+
 func TestTrafficAccumulation(t *testing.T) {
 	tr := New()
 


### PR DESCRIPTION
## Summary

- **Online count fix**: The tracker previously counted every active connection as one "online" entry, inflating device counts for users with multiple concurrent connections from the same IP. Changed to count **unique source IPs** per user, reflecting actual distinct devices.
- **Consistent IP sorting**: xray dispatcher now uses `netip.Addr.Compare` for deterministic IP ordering in device-limit checks, matching sing-box behavior (avoids lexicographic quirks like `"10.x" < "192.x"` and IPv6 mis-ordering).
- **OOM protection**: Capped xray dispatcher's connection tracking map at 100k entries to prevent unbounded memory growth under connection floods.
- **Flush/Restore for online counts**: Added `FlushOnline()` / `RestoreOnline()` to avoid losing online data when a panel push fails, consistent with existing `FlushTraffic` / `RestoreTraffic` semantics.

## Files changed

| File | Change |
|------|--------|
| `internal/tracker/tracker.go` | Rebuild online from unique IPs; add FlushOnline/RestoreOnline |
| `internal/tracker/tracker_test.go` | 3 new tests: unique IP counting, flush, restore |
| `internal/kernel/xray/dispatcher.go` | netip.Addr.Compare sorting + maxConns cap |
| `internal/service/service.go` | Use FlushOnline + RestoreOnline on push failure |

## Test plan

- [x] `TestOnlineCountsUniqueIPs` — 3 connections from 2 IPs → online = 2
- [x] `TestFlushOnline` — flush returns correct data and clears state
- [x] `TestRestoreOnline` — restore works after flush
- [x] All existing tracker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)