### PR TITLE
安装脚本支持Alpine系统,编译开启grpc模块,添加中文readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w \
     -X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo dev) \
     -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    -tags "with_quic with_utls with_wireguard with_clash_api" \
+    -tags "with_quic with_grpc with_utls with_wireguard with_clash_api" \
     -o xboard-node ./cmd/xboard-node
 
 # Runtime stage — sing-box & xray-core are embedded as Go libraries

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ build:
 
 # Build for Linux amd64
 build-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -tags "with_quic with_utls with_wireguard with_acme with_clash_api" -o xboard-node-linux-amd64 ./cmd/xboard-node
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -tags "with_quic with_grpc with_utls with_wireguard with_acme with_clash_api" -o xboard-node-linux-amd64 ./cmd/xboard-node
 
 # Build for Linux arm64
 build-linux-arm64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -tags "with_quic with_utls with_wireguard with_acme with_clash_api" -o xboard-node-linux-arm64 ./cmd/xboard-node
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -tags "with_quic with_grpc with_utls with_wireguard with_acme with_clash_api" -o xboard-node-linux-arm64 ./cmd/xboard-node
 
 # Build all platforms
 build-all: build-linux build-linux-arm64

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME) -X m
 
 # Build for current platform
 build:
-	go build -ldflags "$(LDFLAGS)" -tags "with_quic with_utls with_wireguard with_clash_api" -o xboard-node ./cmd/xboard-node
+	go build -ldflags "$(LDFLAGS)" -tags "with_quic with_grpc with_utls with_wireguard with_clash_api" -o xboard-node ./cmd/xboard-node
 
 # Build for Linux amd64
 build-linux:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,45 @@
 # xboard-node
 
+[English](README.md) | [中文文档](README_CN.md)
+
 Dedicated node backend for [Xboard](https://github.com/cedar2025/Xboard). Fully compatible with Xboard API.
 
 > **Disclaimer**: This project is for educational and learning purposes only.
 
 ## Install
 
+### Install Script
+
+Supports: Ubuntu 20+, Debian 11+, CentOS 8+, Alpine 3.18+
+
+```bash
+# One-command deploy
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 1
+
+# With xray kernel
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 2 -k xray
+
+# Docker mode
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 3 --docker
+
+# Interactive mode
+bash install.sh
+```
+
+**Management:**
+```bash
+bash install.sh list              # List all nodes
+bash install.sh remove <node_id>  # Remove a node
+bash install.sh update            # Update binary and restart
+bash install.sh uninstall         # Remove everything
+```
+
 ### Docker
+
 ```bash
 docker run -d --restart=always --network=host \
-  -e apiHost=https://panel.com \
-  -e apiKey=TOKEN \
+  -e apiHost=https://panel.example.com \
+  -e apiKey=YOUR_TOKEN \
   -e nodeID=1 \
   ghcr.io/cedar2025/xboard-node:latest
 ```
@@ -23,7 +52,6 @@ docker run -d --restart=always --network=host \
 git clone -b compose --depth 1 https://github.com/cedar2025/xboard-node.git
 cd xboard-node
 ```
-
 
 **2. Edit local config**
 
@@ -38,25 +66,50 @@ vim config/config.yml
 docker compose up -d
 ```
 
+## Service Management
+
+### Systemd (Ubuntu/Debian/CentOS)
+
+```bash
+systemctl status xboard-node@1
+journalctl -u xboard-node@1 -f
+systemctl restart xboard-node@1
+```
+
+### OpenRC (Alpine Linux)
+
+```bash
+rc-service xboard-node-1 status
+tail -f /var/log/xboard-node-1.log
+rc-service xboard-node-1 restart
+```
+
 ## Features
 
-- **Kernels**: sing-box (default) / Xray-core.
-- **Protocols**: Full coverage (V2Ray, Trojan, SS, Hysteria2, TUIC, Naive).
-- **Speed**: Kernel-level rate limiting.
-- **Sync**: Real-time WebSocket + REST fallback.
-- **Dev**: Single Go binary.
+- **Kernels**: sing-box (default) / Xray-core
+- **Protocols**: Full coverage (V2Ray, Trojan, SS, Hysteria2, TUIC, Naive)
+- **Speed**: Kernel-level rate limiting
+- **Sync**: Real-time WebSocket + REST fallback
+- **Multi-Node**: Deploy multiple nodes on one server
+- **Service**: systemd / OpenRC / Docker
+- **Dev**: Single Go binary
 
 ## Configuration
 
 `config.yml`:
 ```yaml
 panel:
-  url: "https://panel.com"
-  token: "token"
+  url: "https://panel.example.com"
+  token: "your_token"
   node_id: 1
+
+kernel:
+  type: "singbox"  # singbox or xray
 ```
+
+See [config.yml.example](config.yml.example) for all options.
 
 ## License
 
-MPL-2.0.
+MPL-2.0
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,114 @@
+# xboard-node
+
+[English](README.md) | [中文文档](README_CN.md)
+
+Xboard 面板专用节点后端，完全兼容 [Xboard](https://github.com/cedar2025/Xboard) API。
+
+> **免责声明**：本项目仅供教育和学习目的使用。
+
+## 安装
+
+### 安装脚本
+
+支持系统：Ubuntu 20+、Debian 11+、CentOS 8+、Alpine 3.18+
+
+```bash
+# 一键部署
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 1
+
+# 使用 xray 内核
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 2 -k xray
+
+# Docker 模式
+bash install.sh -a https://panel.example.com -t YOUR_TOKEN -n 3 --docker
+
+# 交互式安装
+bash install.sh
+```
+
+**管理命令：**
+```bash
+bash install.sh list              # 列出所有节点
+bash install.sh remove <node_id>  # 删除节点
+bash install.sh update            # 更新并重启
+bash install.sh uninstall         # 卸载所有
+```
+
+### Docker
+
+```bash
+docker run -d --restart=always --network=host \
+  -e apiHost=https://panel.example.com \
+  -e apiKey=YOUR_TOKEN \
+  -e nodeID=1 \
+  ghcr.io/cedar2025/xboard-node:latest
+```
+
+### Docker Compose
+
+**1. 获取 `compose/` 目录**
+
+```bash
+git clone -b compose --depth 1 https://github.com/cedar2025/xboard-node.git
+cd xboard-node
+```
+
+**2. 编辑本地配置**
+
+```bash
+vim config/config.yml
+# 编辑 config/config.yml — 设置 panel.url、panel.token、panel.node_id
+```
+
+**3. 启动**
+
+```bash
+docker compose up -d
+```
+
+## 服务管理
+
+### Systemd（Ubuntu/Debian/CentOS）
+
+```bash
+systemctl status xboard-node@1
+journalctl -u xboard-node@1 -f
+systemctl restart xboard-node@1
+```
+
+### OpenRC（Alpine Linux）
+
+```bash
+rc-service xboard-node-1 status
+tail -f /var/log/xboard-node-1.log
+rc-service xboard-node-1 restart
+```
+
+## 功能特性
+
+- **双内核**：sing-box（默认）/ Xray-core
+- **协议支持**：V2Ray、Trojan、Shadowsocks、Hysteria2、TUIC、Naive
+- **速率限制**：内核级速率控制
+- **实时同步**：WebSocket + REST 回退
+- **多节点**：单服务器部署多个节点
+- **服务管理**：systemd / OpenRC / Docker
+- **开发友好**：单个 Go 二进制文件
+
+## 配置
+
+`config.yml`：
+```yaml
+panel:
+  url: "https://panel.example.com"
+  token: "your_token"
+  node_id: 1
+
+kernel:
+  type: "singbox"  # singbox 或 xray
+```
+
+完整配置选项请查看 [config.yml.example](config.yml.example)。
+
+## 许可证
+
+MPL-2.0

--- a/install.sh
+++ b/install.sh
@@ -227,6 +227,51 @@ UNIT
     log_info "Systemd template installed: ${SERVICE_TEMPLATE}"
 }
 
+# ─── OpenRC Template ──────────────────────────────────────────────────
+
+install_openrc_template() {
+    if ! command -v rc-service >/dev/null 2>&1; then
+        return
+    fi
+
+    # OpenRC doesn't use templates, create service per node
+    local node_id="$1"
+    local service_name="xboard-node-${node_id}"
+    local service_file="/etc/init.d/${service_name}"
+
+    if [ -f "$service_file" ]; then
+        return
+    fi
+
+    log_step "Installing OpenRC service: ${service_name}..."
+
+    cat > "$service_file" << EOF
+#!/sbin/openrc-run
+
+name="${service_name}"
+description="Xboard Node Backend (node ${node_id})"
+command="/usr/local/bin/xboard-node"
+command_args="-c /etc/xboard-node/${node_id}/config.yml"
+command_background=true
+pidfile="/run/\${RC_SVCNAME}.pid"
+output_log="/var/log/\${RC_SVCNAME}.log"
+error_log="/var/log/\${RC_SVCNAME}.err"
+
+depend() {
+    need net
+    after firewall
+}
+
+start_pre() {
+    checkpath --directory --mode 0755 /var/log
+    checkpath --directory --mode 0755 /run
+}
+EOF
+
+    chmod +x "$service_file"
+    log_info "OpenRC service installed: ${service_name}"
+}
+
 # ─── Migrate Legacy Config ───────────────────────────────────────────
 
 migrate_legacy_config() {
@@ -357,8 +402,13 @@ add_node_native() {
         systemctl enable "xboard-node@${node_id}"
         systemctl start "xboard-node@${node_id}"
         log_info "Service started: xboard-node@${node_id}"
+    elif command -v rc-service >/dev/null 2>&1; then
+        install_openrc_template "$node_id"
+        rc-update add "xboard-node-${node_id}" default
+        rc-service "xboard-node-${node_id}" start
+        log_info "Service started: xboard-node-${node_id}"
     else
-        log_warn "No systemd found. Start manually:"
+        log_warn "No service manager found. Start manually:"
         echo "  xboard-node -c ${CONFIG_DIR}/${node_id}/config.yml"
     fi
 }
@@ -461,12 +511,18 @@ deploy_node() {
         echo "    Logs:    docker logs -f xboard-node-${NODE_ID}"
         echo "    Stop:    cd ${CONFIG_DIR} && docker compose stop node-${NODE_ID}"
         echo "    Restart: cd ${CONFIG_DIR} && docker compose restart node-${NODE_ID}"
-    else
+    elif command -v systemctl >/dev/null 2>&1; then
         echo "  Manage:"
         echo "    Status:  systemctl status xboard-node@${NODE_ID}"
         echo "    Logs:    journalctl -u xboard-node@${NODE_ID} -f"
         echo "    Stop:    systemctl stop xboard-node@${NODE_ID}"
         echo "    Restart: systemctl restart xboard-node@${NODE_ID}"
+    elif command -v rc-service >/dev/null 2>&1; then
+        echo "  Manage:"
+        echo "    Status:  rc-service xboard-node-${NODE_ID} status"
+        echo "    Logs:    tail -f /var/log/xboard-node-${NODE_ID}.log"
+        echo "    Stop:    rc-service xboard-node-${NODE_ID} stop"
+        echo "    Restart: rc-service xboard-node-${NODE_ID} restart"
     fi
 
     echo ""
@@ -491,12 +547,24 @@ remove_node() {
 
     log_step "Removing node ${node_id}..."
 
+    # Stop and disable systemd service
     if command -v systemctl >/dev/null 2>&1; then
         systemctl stop "xboard-node@${node_id}" 2>/dev/null || true
         systemctl disable "xboard-node@${node_id}" 2>/dev/null || true
         log_info "Systemd service stopped and disabled"
     fi
 
+    # Stop and disable OpenRC service
+    if command -v rc-service >/dev/null 2>&1; then
+        if [ -f "/etc/init.d/xboard-node-${node_id}" ]; then
+            rc-service "xboard-node-${node_id}" stop 2>/dev/null || true
+            rc-update del "xboard-node-${node_id}" default 2>/dev/null || true
+            rm -f "/etc/init.d/xboard-node-${node_id}"
+            log_info "OpenRC service stopped and removed"
+        fi
+    fi
+
+    # Stop and remove Docker container
     if command -v docker >/dev/null 2>&1; then
         docker rm -f "xboard-node-${node_id}" 2>/dev/null || true
     fi
@@ -528,11 +596,24 @@ list_nodes() {
         kernel_type=$(grep -E '^\s*type:' "${dir}config.yml" 2>/dev/null | head -1 | sed 's/.*type:\s*"\?\([^"]*\)"\?.*/\1/')
 
         local status="${RED}stopped${NC}"
+        
+        # Check systemd
         if command -v systemctl >/dev/null 2>&1; then
             if systemctl is-active "xboard-node@${nid}" >/dev/null 2>&1; then
                 status="${GREEN}running (systemd)${NC}"
             fi
         fi
+        
+        # Check OpenRC
+        if command -v rc-service >/dev/null 2>&1; then
+            if [ -f "/etc/init.d/xboard-node-${nid}" ]; then
+                if rc-service "xboard-node-${nid}" status >/dev/null 2>&1; then
+                    status="${GREEN}running (openrc)${NC}"
+                fi
+            fi
+        fi
+        
+        # Check Docker
         if command -v docker >/dev/null 2>&1; then
             if docker inspect -f '{{.State.Running}}' "xboard-node-${nid}" 2>/dev/null | grep -q true; then
                 status="${GREEN}running (docker)${NC}"
@@ -574,6 +655,7 @@ update_binary() {
         exit 1
     fi
 
+    # Restart systemd services
     if command -v systemctl >/dev/null 2>&1; then
         for dir in "${CONFIG_DIR}"/*/; do
             [ -f "${dir}config.yml" ] || continue
@@ -582,6 +664,21 @@ update_binary() {
             if systemctl is-active "xboard-node@${nid}" >/dev/null 2>&1; then
                 systemctl restart "xboard-node@${nid}"
                 log_info "Restarted: xboard-node@${nid}"
+            fi
+        done
+    fi
+
+    # Restart OpenRC services
+    if command -v rc-service >/dev/null 2>&1; then
+        for dir in "${CONFIG_DIR}"/*/; do
+            [ -f "${dir}config.yml" ] || continue
+            local nid
+            nid=$(basename "$dir")
+            if [ -f "/etc/init.d/xboard-node-${nid}" ]; then
+                if rc-service "xboard-node-${nid}" status >/dev/null 2>&1; then
+                    rc-service "xboard-node-${nid}" restart 2>/dev/null || log_warn "Failed to restart xboard-node-${nid}"
+                    log_info "Restarted: xboard-node-${nid}"
+                fi
             fi
         done
     fi
@@ -595,6 +692,7 @@ update_binary() {
 do_uninstall() {
     log_step "Uninstalling xboard-node..."
 
+    # Stop and disable all systemd services
     if command -v systemctl >/dev/null 2>&1; then
         for dir in "${CONFIG_DIR}"/*/; do
             [ -f "${dir}config.yml" ] || continue
@@ -610,6 +708,21 @@ do_uninstall() {
         systemctl daemon-reload
     fi
 
+    # Stop and disable all OpenRC services
+    if command -v rc-service >/dev/null 2>&1; then
+        for dir in "${CONFIG_DIR}"/*/; do
+            [ -f "${dir}config.yml" ] || continue
+            local nid
+            nid=$(basename "$dir")
+            if [ -f "/etc/init.d/xboard-node-${nid}" ]; then
+                rc-service "xboard-node-${nid}" stop 2>/dev/null || true
+                rc-update del "xboard-node-${nid}" default 2>/dev/null || true
+            fi
+        done
+        rm -f /etc/init.d/xboard-node-*
+    fi
+
+    # Stop and remove all Docker containers
     if command -v docker >/dev/null 2>&1; then
         for dir in "${CONFIG_DIR}"/*/; do
             [ -f "${dir}config.yml" ] || continue


### PR DESCRIPTION
## Changes

### Install Script (`install.sh`)
- Added `install_openrc_template()` function to create OpenRC service files per node
- Updated `add_node_native()` to detect and use OpenRC when available
- Updated `list_nodes()` to show OpenRC service status
- Updated `remove_node()` to properly stop and remove OpenRC services
- Updated `update_binary()` to restart OpenRC services after binary updates
- Updated `do_uninstall()` to clean up all OpenRC services

### Documentation
- Updated `README.md` with OpenRC service management commands
- Added `README_CN.md` (Chinese documentation) with complete usage guide
- Both READMEs now document OpenRC commands alongside systemd

## Service Management

### OpenRC (Alpine Linux)
```bash
rc-service xboard-node-1 status     # Check status
tail -f /var/log/xboard-node-1.log  # View logs
rc-service xboard-node-1 restart    # Restart service