### PR TITLE
feat: force-close connections on user removal

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -672,6 +672,12 @@ func (s *Service) applyUserDelta(ctx context.Context, action string, deltaUsers 
 			return
 		}
 
+		// Force-close active connections for removed users before revoking
+		// their credentials. Without this, existing long-lived connections
+		// (QUIC/TCP) persist until natural timeout — subscription resets
+		// and bans would not take immediate effect.
+		s.closeConnectionsForUsers(ctx, deltaUsers)
+
 		removed, err := s.kernel.RemoveUsers(deltaUsers)
 		if err != nil {
 			slog.Warn("RemoveUsers failed, falling back to full UpdateUsers", "error", err)
@@ -925,4 +931,41 @@ func computeUserHash(users []panel.User) string {
 		h.Write(buf[:])
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// closeConnectionsForUsers terminates all active connections belonging to
+// the given users. It snapshots active connections from the kernel and closes
+// those matching any of the removed user IDs. This is best-effort: kernels
+// that do not support force-closing (e.g. xray without LimitDispatcher)
+// will silently skip, and connections will eventually time out naturally.
+func (s *Service) closeConnectionsForUsers(ctx context.Context, users []panel.User) {
+	if len(users) == 0 {
+		return
+	}
+
+	conns, err := s.kernel.GetConnections(ctx)
+	if err != nil {
+		slog.Debug("cannot snapshot connections for force-close", "error", err)
+		return
+	}
+
+	removeSet := make(map[int]struct{}, len(users))
+	for _, u := range users {
+		removeSet[u.ID] = struct{}{}
+	}
+
+	var closed int
+	for _, conn := range conns {
+		if _, ok := removeSet[conn.UserID]; ok {
+			if err := s.kernel.CloseConnection(ctx, conn.ID); err != nil {
+				slog.Debug("failed to close connection", "conn_id", conn.ID, "error", err)
+			} else {
+				closed++
+			}
+		}
+	}
+
+	if closed > 0 {
+		slog.Info("force-closed connections for removed users", "closed", closed, "users", len(users))
+	}
 }


### PR DESCRIPTION
## Summary

When users are removed via `sync.user.delta` (e.g. subscription reset, ban), their existing long-lived connections (QUIC sessions, TCP streams) persist until natural timeout. This means **subscription resets do not take immediate effect** — users can continue using the proxy for minutes or even hours.

- Adds `closeConnectionsForUsers()` in `service.go` — snapshots active connections and closes those belonging to removed users **before** revoking credentials
- Uses existing `GetConnections` + `CloseConnection` kernel interface — no interface changes needed
- Best-effort: kernels that don't support force-close silently skip
- Works for both sing-box and xray (via LimitDispatcher)

## Test plan

- [ ] Reset a user's subscription while they have active connections
- [ ] Verify connections are terminated within seconds (not minutes)
- [ ] Verify new connections with old UUID are rejected
- [ ] Verify other users' connections are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)