### PR TITLE
feat: add direct protocol support for singbox custom outbounds

### DIFF
--- a/internal/model/custom_outbound_support.go
+++ b/internal/model/custom_outbound_support.go
@@ -33,6 +33,7 @@ func OutboundSupportMatrix() map[string]KernelOutboundSupport {
 				"anytls",
 				"naive",
 				"mieru",
+				"direct",
 			},
 			Features: []string{
 				"tag",


### PR DESCRIPTION
Allow bind_interface binding via WireGuard or other network interfaces. Closes cedar2025/Xboard-Node#59