### PR TITLE
feat(cert): configurable DNS-01 propagation delay (fix "secondary validation: NXDOMAIN")

### DIFF
--- a/internal/cert/cert.go
+++ b/internal/cert/cert.go
@@ -502,7 +502,25 @@ func (m *Manager) buildDNSSolver() (*certmagic.DNS01Solver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &certmagic.DNS01Solver{DNSManager: certmagic.DNSManager{DNSProvider: provider}}, nil
+	// By default certmagic asks the CA to validate the DNS-01 challenge almost
+	// immediately after creating the TXT record (PropagationDelay == 0). Providers
+	// with slow or inconsistent global anycast propagation (e.g. DNSPod) can then
+	// fail Let's Encrypt's multi-perspective validation with
+	// "During secondary validation: ... NXDOMAIN": the record is visible from one
+	// vantage point but has not propagated to all of the CA's checkers yet.
+	// Allow waiting for propagation before validation via
+	// XBOARD_DNS_PROPAGATION_DELAY (Go duration, e.g. "120s"). Default 0 keeps the
+	// current behavior.
+	var propagationDelay time.Duration
+	if v := strings.TrimSpace(os.Getenv("XBOARD_DNS_PROPAGATION_DELAY")); v != "" {
+		if d, perr := time.ParseDuration(v); perr == nil {
+			propagationDelay = d
+		}
+	}
+	return &certmagic.DNS01Solver{DNSManager: certmagic.DNSManager{
+		DNSProvider:      provider,
+		PropagationDelay: propagationDelay,
+	}}, nil
 }
 
 func (m *Manager) newDNSProvider() (certmagic.DNSProvider, error) {


### PR DESCRIPTION
## Problem

With `cert_mode: dns`, certificate issuance fails against DNS providers that have slow or inconsistent global anycast propagation — most notably **DNSPod** — with:

```
error validating authorization ... "problem": {"type": "urn:ietf:params:acme:error:dns",
  "detail": "During secondary validation: DNS problem: NXDOMAIN looking up TXT for
             _acme-challenge.<domain> - check that a DNS record exists for this domain"}
```

Let's Encrypt now performs **Multi-Perspective Issuance Corroboration (MPIC)** — it validates the DNS-01 challenge from several network vantage points. certmagic's `DNSManager.PropagationDelay` defaults to `0`, so xboard-node asks the CA to validate almost immediately after creating the TXT record. The record is already visible from one location, but has not yet propagated to all of the provider's anycast nodes, so LE's secondary perspectives get `NXDOMAIN` and issuance fails.

(`lego` — used by XrayR / V2bX — waits for propagation before validating, which is why the *same domain + same DNSPod credentials* obtain a cert there but fail here.)

## Fix

Expose certmagic's `PropagationDelay` via the `XBOARD_DNS_PROPAGATION_DELAY` environment variable (a Go duration, e.g. `120s`). **Default `0` preserves the current behavior** — this is purely opt-in.

```
# for slow providers like DNSPod, set in the service environment:
XBOARD_DNS_PROPAGATION_DELAY=120s
```

## Testing

Verified end-to-end against DNSPod (`tencentcloud` provider), on both LE **staging** and **production**, on a real node with `cert_mode: dns`:

- with the default (`0s`): reproduces `During secondary validation ... NXDOMAIN`;
- with `XBOARD_DNS_PROPAGATION_DELAY=120s`: the challenge TXT appears on the authoritative NS within ~6s, is given time to propagate, and MPIC validation then succeeds → `certificate obtained successfully`.

## Notes

- This is a global, ACME-client-level knob (applies to all `dns`-mode instances), not a per-node property, hence an env var rather than per-node config.
- Happy to instead / also surface it as a `config.yml` option (e.g. under `kernel` or a new `acme` block) if you prefer — just say the word.
